### PR TITLE
Add modifier limits

### DIFF
--- a/scripts/masks.js
+++ b/scripts/masks.js
@@ -8,6 +8,8 @@ Hooks.once('pbtaSheetConfig', () => {
             "label": "Locked",
             "modifier": 0
         },
+        "minMod": -3,
+        "maxMod": 4,
         "rollResults": {
             "failure": {
                 "start": null,

--- a/templates/masks.txt
+++ b/templates/masks.txt
@@ -1,6 +1,8 @@
 # Configure Rolls
 rollFormula = "2d6"
 statToggle = "Locked"
+minMod = -3
+maxMod = 4
 
 # Define roll result ranges.
 [rollResults]


### PR DESCRIPTION
This depends on a pending code change to the PbtA module (see https://gitlab.com/asacolips-projects/foundry-mods/pbta/-/merge_requests/26 ) before it will work.

This is to bring things in line with Masks p32, where modifiers on a roll are capped to the range -3 to +4.

This is a draft until the linked GitLab MR is merged.

As is traditional, I offer a cute animal picture as thanks for your consideration:

![Quokka](https://www.rd.com/wp-content/uploads/2021/04/GettyImages-1145794687.jpg?resize=1536,1024)